### PR TITLE
Easier SQL backends

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,10 +13,11 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
-Imports: 
+Imports:
     attempt,
-    R6 (>= 2.5.0)
-Suggests: 
+    R6 (>= 2.5.0),
+Suggests:
+    memoise,
     mongolite (>= 2.2.0),
     redux (>= 1.1.0),
     DBI,

--- a/R/postgres.R
+++ b/R/postgres.R
@@ -32,6 +32,9 @@ cache_postgres <- R6::R6Class(
 
       private$compress <- compress
     },
+    #' @description
+    #' Closes the connection
+    #' @return TRUE, invisibly.
     finalize = function() {
       DBI::dbDisconnect(private$interface)
     },

--- a/R/postgres.R
+++ b/R/postgres.R
@@ -1,13 +1,13 @@
-#' A Caching object for postgres
+#' A Caching object for Postgres
 #'
-#' Create a cache backend with redis
+#' Create a cache backend with Postgres
 #'
 #' @export
 cache_postgres <- R6::R6Class(
   "cache_postgres",
   public = list(
     #' @description
-    #' Start a new redis cache
+    #' Start a new Postgres cache
     #' @param ... Parameters passes do DBI::dbConnect(RPostgres::Postgres(), ...)
     #' @param cache_table On `initialize()`, the cache object will create a table
     #' to store the cache. Default name is `bankrcache`. Change it if you already
@@ -19,67 +19,21 @@ cache_postgres <- R6::R6Class(
                           cache_table = "bankrcache",
                           algo = "sha512",
                           compress = FALSE) {
-      if (!requireNamespace("RPostgres")) {
-        stop(
-          paste(
-            "The {RPostgres} package has to be installed before using `cache_postgres`.",
-            "Please install it first, for example with install.packages('RPostgres').",
-            sep = "\n"
-          )
-        )
-      }
-      if (!requireNamespace("DBI")) {
-        stop(
-          paste(
-            "The {DBI} package has to be installed before using `cache_redis`.",
-            "Please install it first, for example with install.packages('DBI').",
-            sep = "\n"
-          )
-        )
-      }
-      private$interface <- DBI::dbConnect(
-        RPostgres::Postgres(),
-        ...
-      )
+
+      private$check_dependencies("cache_postgres", "RPostgres")
+
+      private$interface <- private$connect(RPostgres::Postgres(), ...)
 
       private$cache_table <- cache_table
 
-      if (
-        cache_table %in% DBI::dbListTables(private$interface)
-      ) {
-        res <- DBI::dbGetQuery(
-          private$interface,
-          sprintf(
-            "SELECT COLUMN_NAME ,DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '%s';",
-            cache_table
-          )
-        )
-        names(res) <- tolower(names(res))
-        attempt::stop_if_not(
-          nrow(res) == 2,
-          msg = "Your cache_table your only have two column"
-        )
-        attempt::stop_if_not(
-          all(c("cache", "id") %in% res$column_name),
-          msg = "Your cache_db should have a `cache` and an `id` column."
-        )
-        attempt::stop_if_not(
-          all(c("character varying", "bytea") %in% res$data_type),
-          msg = "Your cache_table data types should be `bytea` and `character varying`."
-        )
-      } else {
-        DBI::dbCreateTable(
-          private$interface,
-          cache_table,
-          fields = c(
-            id = "VARCHAR",
-            cache = "BYTEA"
-          )
-        )
-      }
+      private$check_table()
 
       private$algo <- algo
+
       private$compress <- compress
+    },
+    finalize = function() {
+      DBI::dbDisconnect(private$interface)
     },
     #' @description
     #' Does the cache contains a given key?
@@ -176,14 +130,7 @@ cache_postgres <- R6::R6Class(
         private$interface,
         private$cache_table
       )
-      DBI::dbCreateTable(
-        private$interface,
-        private$cache_table,
-        fields = c(
-          id = "VARCHAR",
-          cache = "BYTEA"
-        )
-      )
+      private$create_table()
     },
     #' @description
     #' Remove a key/value pair
@@ -219,7 +166,81 @@ cache_postgres <- R6::R6Class(
     digest = function(...) digest::digest(..., algo = private$algo)
   ),
   private = list(
-    interface = list(),
+    check_dependencies = function(class_name = character(),
+                                  packages = character()) {
+
+      needed_packages <- c("DBI", packages)
+
+      stopper <- function(package) {
+
+        if( !requireNamespace(package) ) {
+          stop(
+            paste0(
+              "The {", package, "} package has to be installed before using `",
+              class_name, "`. Please install it first, for example with
+              install.packages('", package, "')."
+            ),
+            call. = FALSE
+          )
+        }
+
+      }
+
+      lapply(needed_packages, FUN = stopper)
+
+    },
+    connect = function(...) {
+      DBI::dbConnect(...)
+    },
+    sql_column_data = list(
+      column_id = list(type = "VARCHAR", type_description = "character varying"),
+      column_cache = list(type = "BYTEA", type_description = "bytea")
+    ),
+    check_table = function() {
+      if (
+        private$cache_table %in% DBI::dbListTables(private$interface)
+      ) {
+        res <- DBI::dbGetQuery(
+          private$interface,
+          sprintf(
+            "SELECT COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '%s';",
+            private$cache_table
+          )
+        )
+        names(res) <- tolower(names(res))
+        attempt::stop_if_not(
+          nrow(res) == 2,
+          msg = "Your cache_table should have only two columns"
+        )
+        attempt::stop_if_not(
+          all(c("cache", "id") %in% res$column_name),
+          msg = "Your cache_db should have a `cache` and an `id` column."
+        )
+        attempt::stop_if_not(
+          all(c(private$sql_column_data$column_id$type_description,
+                private$sql_column_data$column_cache$type_description) %in%
+                res$data_type),
+          msg = paste0("Your cache_table data types should be `",
+                       private$sql_column_data$column_id$type_description,
+                       "` and `",
+                       private$sql_column_data$column_cache$type_description,
+                       ".")
+        )
+      } else {
+        private$create_table()
+      }
+    },
+    create_table = function() {
+      DBI::dbCreateTable(
+        private$interface,
+        private$cache_table,
+        fields = c(
+          id = private$sql_column_data$column_id$type,
+          cache = private$sql_column_data$column_cache$type
+        )
+      )
+    },
+    interface = list(0),
     cache_table = character(0),
     algo = character(0),
     compress = logical(0)

--- a/man/cache_postgres.Rd
+++ b/man/cache_postgres.Rd
@@ -2,19 +2,20 @@
 % Please edit documentation in R/postgres.R
 \name{cache_postgres}
 \alias{cache_postgres}
-\title{A Caching object for postgres}
+\title{A Caching object for Postgres}
 \description{
-A Caching object for postgres
+A Caching object for Postgres
 
-A Caching object for postgres
+A Caching object for Postgres
 }
 \details{
-Create a cache backend with redis
+Create a cache backend with Postgres
 }
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-new}{\code{cache_postgres$new()}}
+\item \href{#method-finalize}{\code{cache_postgres$finalize()}}
 \item \href{#method-has_key}{\code{cache_postgres$has_key()}}
 \item \href{#method-get}{\code{cache_postgres$get()}}
 \item \href{#method-set}{\code{cache_postgres$set()}}
@@ -29,7 +30,7 @@ Create a cache backend with redis
 \if{html}{\out{<a id="method-new"></a>}}
 \if{latex}{\out{\hypertarget{method-new}{}}}
 \subsection{Method \code{new()}}{
-Start a new redis cache
+Start a new Postgres cache
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{cache_postgres$new(
   ...,
@@ -57,6 +58,15 @@ have a table named \code{bankrcache} in your DB.}
 \subsection{Returns}{
 A cache_postgres object
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-finalize"></a>}}
+\if{latex}{\out{\hypertarget{method-finalize}{}}}
+\subsection{Method \code{finalize()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{cache_postgres$finalize()}\if{html}{\out{</div>}}
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-has_key"></a>}}

--- a/man/cache_postgres.Rd
+++ b/man/cache_postgres.Rd
@@ -63,10 +63,14 @@ A cache_postgres object
 \if{html}{\out{<a id="method-finalize"></a>}}
 \if{latex}{\out{\hypertarget{method-finalize}{}}}
 \subsection{Method \code{finalize()}}{
+Closes the connection
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{cache_postgres$finalize()}\if{html}{\out{</div>}}
 }
 
+\subsection{Returns}{
+TRUE, invisibly.
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-has_key"></a>}}

--- a/tests/testthat/helpers-utils.R
+++ b/tests/testthat/helpers-utils.R
@@ -3,7 +3,7 @@ test_them_all <- function(cache_obj) {
         sample(1:1000, x)
     }
 
-    mf <- memoise(f, cache = cache_obj)
+    mf <- memoise::memoise(f, cache = cache_obj)
     expect_equal(
         mf(5),
         mf(5)


### PR DESCRIPTION
Here I changed `cache_postgres` to facilitate new SQL backends, what I have done is:

- In the test file I have only added a call to `{memoise}` to facilitate interactive tests
- As many checks and data were moved to private functions to facilitate the inclusion of new SQL backends. MS SQL Server can, for example, be added like so (I will do it and update the documentation if you are OK with this change):

``` r
cache_ms_sql <- R6::R6Class(
  "cache_ms_sql",
  inherit = cache_postgres,
  public = list(
    #' @description
    #' Start a new Microsoft SQL Server cache
    #' @param ... Parameters passes do DBI::dbConnect(odbc::odbc(), ...)
    #' @param cache_table On `initialize()`, the cache object will create a table
    #' to store the cache. Default name is `bankrcache`. Change it if you already
    #' have a table named `bankrcache` in your DB.
    #' @param algo for `{memoise}` compatibility, the `digest()` algorithm
    #' @param compress for `{memoise}` compatibility, should the data be compressed?
    #' @return A cache_ms_sql object
    initialize = function(...,
                          cache_table = "bankrcache",
                          algo = "sha512",
                          compress = FALSE) {

      private$check_dependencies("cache_ms_sql", "odbc")

      private$interface <- private$connect(odbc::odbc(), ...)

      private$sql_column_data = list(
            column_id = list(type = "varchar(max)", type_description = "varchar"),
            column_cache = list(type = "varbinary(max)", type_description = "varbinary")

      private$cache_table <- cache_table

      private$check_table()

      private$algo <- algo

      private$compress <- compress
    }
  )
)
```